### PR TITLE
Add SMILES to compounds.csv.gz

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -127,3 +127,5 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+
+.DS_Store

--- a/metadata/README.md
+++ b/metadata/README.md
@@ -23,6 +23,7 @@ erDiagram
         string Metadata_JCP2022 PK "JUMP perturbation ID"
         string Metadata_InChI "International Chemical ID"
         string Metadata_InChIKey "Hashed InChI"
+        string Metadata_SMILES "SMILES"
     }
     WELL }o--o| ORF : ""
     ORF {
@@ -87,5 +88,5 @@ erDiagram
     CELLPROFILER-VERSION {
         string Metadata_Source "Data-generating center ID"
         string Metadata_CellProfiler_Version "CellProfiler Version"
-    } 
+    }
 ```


### PR DESCRIPTION
This file adds a standardized SMILES column and the first 14 characters of the InChI key (representing the connectivity) to the compounds.csv.gz We show that six compounds have dual entires, often different ionization states.