### PR TITLE
feat(manifest): add production compound profile

### DIFF
--- a/manifests/profile_index.json
+++ b/manifests/profile_index.json
@@ -21,6 +21,13 @@
     "etag": "c9371af57a36a51e021935c9ca78e506"
   },
   {
+    "subset": "compound_no_source7",
+    "url": "https://cellpainting-gallery.s3.amazonaws.com/cpg0042-chandrasekaran-jump/source_all/workspace/profiles_assembled/compound_no_source7/v1.0/profiles_var_mad_int_featselect_harmony.parquet",
+    "recipe_permalink": "https://github.com/broadinstitute/jump-profiling-recipe/tree/v0.6.0",
+    "config_permalink": "https://github.com/broadinstitute/2025_jump_addon_orchestrator/blob/a15dedb35383cb342cd010106615f99939178126/1.convert/input/compound_no_source7.json",
+    "etag": "178b06851e6c2bc8bfe777d71d87c1a7-53"
+  },
+  {
     "subset": "orf_interpretable",
     "url": "https://cellpainting-gallery.s3.amazonaws.com/cpg0016-jump-assembled/source_all/workspace/profiles_assembled/ORF/v1.0a/profiles_wellpos_cc_var_mad_outlier.parquet",
     "recipe_permalink": "https://github.com/broadinstitute/jump-profiling-recipe/tree/a917fa79342ff92cf0ea05d6d9174d9028a90f8f",


### PR DESCRIPTION
## Summary

- add only the `compound_no_source7` CellProfiler/Harmony profile used by the JUMP production paper to the official profile manifest
- retain permalinks to the producing recipe and configuration
- record the current S3 multipart ETag

This makes the paper-specific production profile discoverable without changing the existing public `compound` or `compound_interpretable` entries. The production workflow can recover its 758 CellProfiler feature names from the pre-Harmony schema, so it does not need another manifest entry. This is prerequisite work for broadinstitute/monorepo#108 and follows the decision in broadinstitute/monorepo#101.

## Validation

- `jq empty manifests/profile_index.json`
- unique subset/schema check with `jq`
- `bash manifests/src/update_etags.sh manifests/profile_index.json` reproduces `178b06851e6c2bc8bfe777d71d87c1a7-53` for the new entry
